### PR TITLE
Update linuxptp version

### DIFF
--- a/package/linuxptp/linuxptp.hash
+++ b/package/linuxptp/linuxptp.hash
@@ -1,9 +1,9 @@
 # From https://sourceforge.net/projects/linuxptp/files/v2.0/
-sha1 592ca42c6146a79c1fcabed7c19fa7af4803d4f6  linuxptp-2.0.tgz
-md5 d8bb7374943bb747db7786ac26f17f11  linuxptp-2.0.tgz
+e3f9a816247abdb4b41790e9c04703848b4d181f  linuxptp-2.0.1.tgz
+md5 896b590b868105bb3838f9c126cf1ae6  linuxptp-2.0.1.tgz
 
 # Locally computed:
-sha256 0a24d9401e87d4af023d201e234d91127d82c350daad93432106284aa9459c7d  linuxptp-2.0.tgz
+sha256 6f4669db1733747427217a9e74c8b5ca25c4245947463e9cdb860ec8f5ec797a  linuxptp-2.0.1.tgz
 
 # Hash for license file:
 sha256 8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643  COPYING

--- a/package/linuxptp/linuxptp.mk
+++ b/package/linuxptp/linuxptp.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LINUXPTP_VERSION = 2.0
+LINUXPTP_VERSION = 2.0.1
 LINUXPTP_SOURCE = linuxptp-$(LINUXPTP_VERSION).tgz
 LINUXPTP_SITE = http://downloads.sourceforge.net/linuxptp
 LINUXPTP_LICENSE = GPL-2.0+


### PR DESCRIPTION
linuxptp v2.0 has been superseded with v2.0.1 version, and the download link has been removed.
Without this patch, the buildroot build process will have 404 not found error because the v2.0 version is superseded .

https://sourceforge.net/projects/linuxptp/files/v2.0/